### PR TITLE
fix typo

### DIFF
--- a/attack_range_local.conf
+++ b/attack_range_local.conf
@@ -238,7 +238,7 @@ phantom_server_private_ip = 10.0.1.13
 phantom_server_cpus = 4
 # specify with how many cpus the machine should be equipted. 
 
-phantom_server__memory = 4096
+phantom_server_memory = 4096
 # specify with how much memory in kb the machine should be equipted.
 # It is not recommended to use any value lower than then default (4096) one.
 


### PR DESCRIPTION
fixng typo in .conf for pahntom setting memory